### PR TITLE
Make header transparent over hero

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -3454,3 +3454,67 @@ details-disclosure > details {
     --border-offset: 0px; /* Prevent the border from growing on buttons when this effect is on. */
   }
 }
+/* ----- Hero overlap header styles ------------------------------------ */
+#SiteHeaderWrapper {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: none;
+  border: none;
+}
+
+#SiteHeader {
+  position: relative;
+  z-index: 1;
+}
+
+/* Transparency over hero */
+#SiteHeaderWrapper.is-transparent {
+  background: transparent;
+}
+#SiteHeaderWrapper.is-transparent #SiteHeader::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.15), rgba(0,0,0,0));
+}
+#SiteHeaderWrapper.is-transparent,
+#SiteHeaderWrapper.is-transparent a,
+#SiteHeaderWrapper.is-transparent summary,
+#SiteHeaderWrapper.is-transparent .header__icon {
+  color: #fff;
+  text-decoration-color: currentColor;
+}
+#SiteHeaderWrapper.is-transparent summary::after {
+  border-top-color: currentColor;
+}
+
+/* Solid glassy state */
+#SiteHeaderWrapper.is-solid {
+  background: rgba(255,255,255,0.96);
+  backdrop-filter: saturate(180%) blur(20px);
+  box-shadow: 0 1px 8px rgba(0,0,0,0.05);
+}
+#SiteHeaderWrapper.is-solid,
+#SiteHeaderWrapper.is-solid a,
+#SiteHeaderWrapper.is-solid summary,
+#SiteHeaderWrapper.is-solid .header__icon {
+  color: #000;
+  text-decoration-color: currentColor;
+}
+#SiteHeaderWrapper.is-solid summary::after {
+  border-top-color: currentColor;
+}
+
+/* Logo visibility */
+.logo--white { display: none; }
+#SiteHeaderWrapper.is-transparent .logo--white { display: block; }
+#SiteHeaderWrapper.is-transparent .logo--black { display: none; }
+#SiteHeaderWrapper.is-solid .logo--white { display: none; }
+#SiteHeaderWrapper.is-solid .logo--black { display: block; }
+
+/* Pull hero up under transparent header */
+.header-overlap .section-header + .shopify-section {
+  margin-top: calc(-1 * var(--header-height));
+}

--- a/assets/header-hero-header.js
+++ b/assets/header-hero-header.js
@@ -1,0 +1,57 @@
+/* header-hero-header.js
+   Sticky + transparent-over-hero header for Dawn 14.0.0
+*/
+document.addEventListener('DOMContentLoaded', () => {
+  const wrapper = document.getElementById('SiteHeaderWrapper');
+  const header  = document.getElementById('SiteHeader');
+  if (!wrapper || !header) return;
+
+  // Force sticky behavior
+  wrapper.dataset.stickyType = 'always';
+
+  const root = document.documentElement;
+  const hero = document.querySelector('.section-header + .shopify-section');
+
+  /* --header-height variable -------------------------------------------- */
+  const setHeaderHeight = () =>
+    root.style.setProperty('--header-height', `${wrapper.offsetHeight}px`);
+
+  new ResizeObserver(() => requestAnimationFrame(setHeaderHeight)).observe(wrapper);
+  new MutationObserver(() => requestAnimationFrame(setHeaderHeight))
+    .observe(wrapper, { childList: true, subtree: true });
+  if (document.fonts) {
+    document.fonts.ready.then(() => requestAnimationFrame(setHeaderHeight));
+  }
+  window.addEventListener('resize', () => requestAnimationFrame(setHeaderHeight));
+  setHeaderHeight();
+
+  /* Overlap detection --------------------------------------------------- */
+  let rafId;
+  const updateState = () => {
+    rafId = null;
+    const heroRect   = hero ? hero.getBoundingClientRect() : null;
+    const headerRect = wrapper.getBoundingClientRect();
+    const overlapping =
+      heroRect &&
+      heroRect.top < headerRect.bottom &&
+      heroRect.bottom > headerRect.top;
+
+    if (overlapping) {
+      wrapper.classList.add('is-transparent');
+      wrapper.classList.remove('is-solid');
+      root.classList.add('header-overlap');
+    } else {
+      wrapper.classList.remove('is-transparent');
+      wrapper.classList.add('is-solid');
+      root.classList.remove('header-overlap');
+    }
+  };
+
+  const onScrollOrResize = () => {
+    if (!rafId) rafId = requestAnimationFrame(updateState);
+  };
+
+  window.addEventListener('scroll', onScrollOrResize, { passive: true });
+  window.addEventListener('resize', onScrollOrResize);
+  updateState(); // initial state
+});

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -134,7 +134,7 @@
   endfor
 -%}
 
-<{% if section.settings.sticky_header_type != 'none' %}sticky-header data-sticky-type="{{ section.settings.sticky_header_type }}"{% else %}div{% endif %} class="header-wrapper color-{{ section.settings.color_scheme }} gradient{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %}">
+<sticky-header id="SiteHeaderWrapper" data-sticky-type="always" class="header-wrapper color-{{ section.settings.color_scheme }} is-transparent">
   {%- liquid
     assign social_links = false
     assign localization_forms = false
@@ -147,7 +147,7 @@
       assign localization_forms = true
     endif
   -%}
-  <header class="header header--{{ section.settings.logo_position }} header--mobile-{{ section.settings.mobile_logo_position }} page-width{% if section.settings.menu_type_desktop == 'drawer' %} drawer-menu{% endif %}{% if section.settings.menu != blank %} header--has-menu{% endif %}{% if has_app_block %} header--has-app{% endif %}{% if social_links %} header--has-social{% endif %}{% if shop.customer_accounts_enabled %} header--has-account{% endif %}{% if localization_forms %} header--has-localizations{% endif %}">
+  <header id="SiteHeader" class="header header--{{ section.settings.logo_position }} header--mobile-{{ section.settings.mobile_logo_position }} page-width{% if section.settings.menu_type_desktop == 'drawer' %} drawer-menu{% endif %}{% if section.settings.menu != blank %} header--has-menu{% endif %}{% if has_app_block %} header--has-app{% endif %}{% if social_links %} header--has-social{% endif %}{% if shop.customer_accounts_enabled %} header--has-account{% endif %}{% if localization_forms %} header--has-localizations{% endif %}">
     {%- liquid
       if section.settings.menu != blank
         render 'header-drawer'
@@ -165,19 +165,10 @@
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               <div class="header__heading-logo-wrapper">
-                {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
-                {%- assign logo_height = settings.logo_width | divided_by: settings.logo.aspect_ratio -%}
-                {% capture sizes %}(max-width: {{ settings.logo_width | times: 2 }}px) 50vw, {{ settings.logo_width }}px{% endcapture %}
-                {% capture widths %}{{ settings.logo_width }}, {{ settings.logo_width | times: 1.5 | round }}, {{ settings.logo_width | times: 2 }}{% endcapture %}
-                {{ settings.logo | image_url: width: 600 | image_tag:
-                  class: 'header__heading-logo motion-reduce',
-                  widths: widths,
-                  height: logo_height,
-                  width: settings.logo_width,
-                  alt: logo_alt,
-                  sizes: sizes,
-                  preload: true
-                }}
+                {%- assign logo_alt = shop.name | escape -%}
+                {% capture logo_widths %}{{ settings.logo_width }}, {{ settings.logo_width | times: 2 }}{% endcapture %}
+                {{ 'logo-white.png' | asset_url | image_tag: class: 'header__heading-logo logo--white', widths: logo_widths, width: settings.logo_width, alt: logo_alt }}
+                {{ 'logo-black.png' | asset_url | image_tag: class: 'header__heading-logo logo--black', widths: logo_widths, width: settings.logo_width, alt: logo_alt }}
               </div>
             {%- else -%}
               <span class="h2">{{ shop.name }}</span>
@@ -205,19 +196,10 @@
           <a href="{{ routes.root_url }}" class="header__heading-link link link--text focus-inset">
             {%- if settings.logo != blank -%}
               <div class="header__heading-logo-wrapper">
-                {%- assign logo_alt = settings.logo.alt | default: shop.name | escape -%}
-                {%- assign logo_height = settings.logo_width | divided_by: settings.logo.aspect_ratio -%}
-                {% capture sizes %}(min-width: 750px) {{ settings.logo_width }}px, 50vw{% endcapture %}
-                {% capture widths %}{{ settings.logo_width }}, {{ settings.logo_width | times: 1.5 | round }}, {{ settings.logo_width | times: 2 }}{% endcapture %}
-                {{ settings.logo | image_url: width: 600 | image_tag:
-                  class: 'header__heading-logo',
-                  widths: widths,
-                  height: logo_height,
-                  width: settings.logo_width,
-                  alt: logo_alt,
-                  sizes: sizes,
-                  preload: true
-                }}
+                {%- assign logo_alt = shop.name | escape -%}
+                {% capture logo_widths %}{{ settings.logo_width }}, {{ settings.logo_width | times: 2 }}{% endcapture %}
+                {{ 'logo-white.png' | asset_url | image_tag: class: 'header__heading-logo logo--white', widths: logo_widths, width: settings.logo_width, alt: logo_alt }}
+                {{ 'logo-black.png' | asset_url | image_tag: class: 'header__heading-logo logo--black', widths: logo_widths, width: settings.logo_width, alt: logo_alt }}
               </div>
             {%- else -%}
               <span class="h2">{{ shop.name }}</span>
@@ -302,7 +284,7 @@
       </a>
     </div>
   </header>
-</{% if section.settings.sticky_header_type != 'none' %}sticky-header{% else %}div{% endif %}>
+</sticky-header>
 
 {%- if settings.cart_type == "notification" -%}
   {%- render 'cart-notification', color_scheme: section.settings.color_scheme, desktop_menu_type: section.settings.menu_type_desktop -%}
@@ -459,6 +441,8 @@
     }
   </script>
 {%- endif -%}
+
+<script src="{{ 'header-hero-header.js' | asset_url }}" defer="defer"></script>
 
 {% schema %}
 {


### PR DESCRIPTION
## Summary
- make header sticky, transparent over hero, and solid elsewhere
- add script to toggle header state and compute header height
- style transparent and solid header variants and swap white/black logos
- remove placeholder logo assets so custom logos can be supplied

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68999ef3e03c832c969f18d4cb4fb297