### PR TITLE
Add PDP Essentials block schema

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -2101,6 +2101,122 @@
           "info": "t:sections.main-product.blocks.icon_with_text.settings.heading.info"
         }
       ]
+    },
+    {
+      "type": "pdp_essentials",
+      "name": "PDP Essentials",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "checkbox",
+          "id": "show_size_link",
+          "default": false,
+          "label": "Show size link"
+        },
+        {
+          "type": "page",
+          "id": "size_guide_page",
+          "label": "Size guide page"
+        },
+        {
+          "type": "text",
+          "id": "delivery_text",
+          "label": "Delivery text"
+        },
+        {
+          "type": "richtext",
+          "id": "delivery_details",
+          "label": "Delivery details"
+        },
+        {
+          "type": "text",
+          "id": "returns_text",
+          "label": "Returns text"
+        },
+        {
+          "type": "richtext",
+          "id": "returns_details",
+          "label": "Returns details"
+        },
+        {
+          "type": "text",
+          "id": "trust_line",
+          "label": "Trust line"
+        },
+        {
+          "type": "header",
+          "content": "Advanced settings"
+        },
+        {
+          "type": "select",
+          "id": "layout_style",
+          "label": "Layout style",
+          "options": [
+            { "value": "icons", "label": "Icons" },
+            { "value": "text", "label": "Text" }
+          ],
+          "default": "icons"
+        },
+        {
+          "type": "select",
+          "id": "link_behavior",
+          "label": "Link behavior",
+          "options": [
+            { "value": "modal", "label": "Modal" },
+            { "value": "link", "label": "Link" }
+          ],
+          "default": "modal"
+        },
+        {
+          "type": "select",
+          "id": "icon_style",
+          "label": "Icon style",
+          "options": [
+            { "value": "outline", "label": "Outline" },
+            { "value": "solid", "label": "Solid" }
+          ],
+          "default": "outline"
+        },
+        {
+          "type": "color",
+          "id": "accent_color",
+          "label": "Accent color"
+        },
+        {
+          "type": "checkbox",
+          "id": "compact_mode",
+          "label": "Compact mode",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "show_dividers",
+          "label": "Show dividers",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "hide_if_empty",
+          "label": "Hide if empty",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "use_metafields",
+          "label": "Use metafields",
+          "default": false
+        },
+        {
+          "type": "text",
+          "id": "delivery_text_in",
+          "label": "Delivery text in"
+        },
+        {
+          "type": "text",
+          "id": "delivery_text_global",
+          "label": "Delivery text global"
+        }
+      ]
     }
   ],
   "settings": [


### PR DESCRIPTION
## Summary
- add `pdp_essentials` block to product section schema
- include core settings like size link, delivery and returns info, and trust line
- expose advanced configuration for layout, links, icons, and behavior options

## Testing
- `npm test` *(fails: Could not read package.json)*
- `theme-check sections/main-product.liquid` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c25c2e98832c8dba009edf835188