### PR TITLE
Render trust line div with mobile truncation

### DIFF
--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -1472,3 +1472,15 @@ a.product__text {
     border: none;
   }
 }
+
+.pdp-essentials__trust-line {
+  margin-top: 1rem;
+}
+
+@media screen and (max-width: 749px) {
+  .pdp-essentials__trust-line {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}

--- a/snippets/pdp-essentials.liquid
+++ b/snippets/pdp-essentials.liquid
@@ -93,9 +93,14 @@
       </ul>
   {% endcase %}
 
-  {%- assign trust_line_text = block.settings.trust_line | default: ('sections.pdp_essentials.trust_line' | t) -%}
+  {%- assign trust_line_setting = block.settings.trust_line -%}
+  {%- if trust_line_setting == blank and block.settings.hide_if_empty -%}
+    {%- assign trust_line_text = blank -%}
+  {%- else -%}
+    {%- assign trust_line_text = trust_line_setting | default: ('sections.pdp_essentials.trust_line' | t) -%}
+  {%- endif -%}
   {%- if trust_line_text != blank -%}
-    <p class="pdp-essentials__trust-line">{{ trust_line_text }}</p>
+    <div class="pdp-essentials__trust-line" title="{{ trust_line_text | escape }}">{{ trust_line_text }}</div>
   {%- endif -%}
 
   <script>


### PR DESCRIPTION
## Summary
- Render trust line in its own div with title tooltip
- Truncate trust line to one line on small screens
- Hide trust line when empty and `hide_if_empty` is enabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d0c8e1c0832ca237b9dc9428aac0