### PR TITLE
Skip empty PDP essentials items when hide_if_empty

### DIFF
--- a/snippets/pdp-essentials.liquid
+++ b/snippets/pdp-essentials.liquid
@@ -20,81 +20,98 @@
   {%- assign delivery_details = block.settings.delivery_details | default: ('sections.pdp_essentials.delivery_details' | t) -%}
   {%- assign returns_title = block.settings.returns_text | default: ('sections.pdp_essentials.returns' | t) -%}
   {%- assign returns_details = block.settings.returns_details | default: ('sections.pdp_essentials.returns_details' | t) -%}
+  {%- assign size_text = 'sections.pdp_essentials.size_and_fit' | t -%}
+  {%- assign hide_if_empty = block.settings.hide_if_empty -%}
 
-  {%- if delivery_details != blank -%}
+  {%- assign show_delivery = delivery_title != blank or delivery_details != blank -%}
+  {%- if hide_if_empty and delivery_title == blank -%}
+    {%- assign show_delivery = false -%}
+  {%- endif -%}
+
+  {%- assign show_returns = returns_title != blank or returns_details != blank -%}
+  {%- if hide_if_empty and returns_title == blank -%}
+    {%- assign show_returns = false -%}
+  {%- endif -%}
+
+  {%- assign show_size_link = block.settings.show_size_link and block.settings.size_guide_page != blank -%}
+  {%- if hide_if_empty and size_text == blank -%}
+    {%- assign show_size_link = false -%}
+  {%- endif -%}
+
+  {%- if show_delivery and delivery_details != blank -%}
     <div id="pdp-delivery-details" hidden>{{ delivery_details }}</div>
   {%- endif -%}
-  {%- if returns_details != blank -%}
+  {%- if show_returns and returns_details != blank -%}
     <div id="pdp-returns-details" hidden>{{ returns_details }}</div>
   {%- endif -%}
 
   {% case layout %}
     {% when 'cards' %}
       <ul style="display:flex;flex-wrap:wrap;list-style:none;margin:0;padding:0;gap:{% if compact %}4px{% else %}8px{% endif %};">
-        {%- if delivery_title != blank or delivery_details != blank -%}
+        {%- if show_delivery -%}
           <li style="{% if dividers %}border:1px solid currentColor;{% endif %}border-radius:9999px;padding:{% if compact %}2px 8px{% else %}4px 12px{% endif %};">
             <button type="button" data-essentials-trigger aria-controls="pdp-delivery-details" style="all:unset;cursor:pointer;">{{ delivery_title }}</button>
           </li>
         {%- endif -%}
 
-        {%- if returns_title != blank or returns_details != blank -%}
+        {%- if show_returns -%}
           <li style="{% if dividers %}border:1px solid currentColor;{% endif %}border-radius:9999px;padding:{% if compact %}2px 8px{% else %}4px 12px{% endif %};">
             <button type="button" data-essentials-trigger aria-controls="pdp-returns-details" style="all:unset;cursor:pointer;">{{ returns_title }}</button>
           </li>
         {%- endif -%}
 
-        {%- if block.settings.show_size_link and block.settings.size_guide_page != blank -%}
+        {%- if show_size_link -%}
           <li style="{% if dividers %}border:1px solid currentColor;{% endif %}border-radius:9999px;padding:{% if compact %}2px 8px{% else %}4px 12px{% endif %};">
-            <a href="{{ block.settings.size_guide_page.url }}"{% unless block.settings.link_behavior == 'modal' %} target="_blank" rel="noopener"{% endunless %} data-size-guide-link data-event="pdp_essentials_click" data-item="size">{{ 'sections.pdp_essentials.size_and_fit' | t }}</a>
+            <a href="{{ block.settings.size_guide_page.url }}"{% unless block.settings.link_behavior == 'modal' %} target="_blank" rel="noopener"{% endunless %} data-size-guide-link data-event="pdp_essentials_click" data-item="size">{{ size_text }}</a>
           </li>
         {%- endif -%}
       </ul>
 
     {% when 'accordion' %}
       <div style="margin:0;padding:0;">
-        {%- if delivery_title != blank or delivery_details != blank -%}
+        {%- if show_delivery -%}
           <div style="padding:{% if compact %}4px 0{% else %}8px 0{% endif %};{% if dividers %}border-bottom:1px solid currentColor;{% endif %}">
             <button type="button" data-essentials-trigger aria-controls="pdp-delivery-details" style="all:unset;cursor:pointer;">{{ delivery_title }}</button>
           </div>
         {%- endif -%}
 
-        {%- if returns_title != blank or returns_details != blank -%}
+        {%- if show_returns -%}
           <div style="padding:{% if compact %}4px 0{% else %}8px 0{% endif %};{% if dividers %}border-bottom:1px solid currentColor;{% endif %}">
             <button type="button" data-essentials-trigger aria-controls="pdp-returns-details" style="all:unset;cursor:pointer;">{{ returns_title }}</button>
           </div>
         {%- endif -%}
 
-        {%- if block.settings.show_size_link and block.settings.size_guide_page != blank -%}
+        {%- if show_size_link -%}
           <div style="padding:{% if compact %}4px 0{% else %}8px 0{% endif %};{% if dividers %}border-bottom:1px solid currentColor;{% endif %}">
-            <a href="{{ block.settings.size_guide_page.url }}"{% unless block.settings.link_behavior == 'modal' %} target="_blank" rel="noopener"{% endunless %} data-size-guide-link data-event="pdp_essentials_click" data-item="size">{{ 'sections.pdp_essentials.size_and_fit' | t }}</a>
+            <a href="{{ block.settings.size_guide_page.url }}"{% unless block.settings.link_behavior == 'modal' %} target="_blank" rel="noopener"{% endunless %} data-size-guide-link data-event="pdp_essentials_click" data-item="size">{{ size_text }}</a>
           </div>
         {%- endif -%}
       </div>
 
     {% else %}
       <ul style="display:flex;flex-wrap:wrap;list-style:none;margin:0;padding:0;gap:{% if compact %}4px{% else %}8px{% endif %};{% if dividers %}border-top:1px solid currentColor;border-bottom:1px solid currentColor;{% endif %}">
-        {%- if delivery_title != blank or delivery_details != blank -%}
+        {%- if show_delivery -%}
           <li style="padding:{% if compact %}4px 8px{% else %}8px 12px{% endif %};{% if dividers %}border-right:1px solid currentColor;{% endif %}">
             <button type="button" data-essentials-trigger aria-controls="pdp-delivery-details" style="all:unset;cursor:pointer;">{{ delivery_title }}</button>
           </li>
         {%- endif -%}
 
-        {%- if returns_title != blank or returns_details != blank -%}
+        {%- if show_returns -%}
           <li style="padding:{% if compact %}4px 8px{% else %}8px 12px{% endif %};{% if dividers %}border-right:1px solid currentColor;{% endif %}">
             <button type="button" data-essentials-trigger aria-controls="pdp-returns-details" style="all:unset;cursor:pointer;">{{ returns_title }}</button>
           </li>
         {%- endif -%}
 
-        {%- if block.settings.show_size_link and block.settings.size_guide_page != blank -%}
+        {%- if show_size_link -%}
           <li style="padding:{% if compact %}4px 8px{% else %}8px 12px{% endif %};">
-            <a href="{{ block.settings.size_guide_page.url }}"{% unless block.settings.link_behavior == 'modal' %} target="_blank" rel="noopener"{% endunless %} data-size-guide-link data-event="pdp_essentials_click" data-item="size">{{ 'sections.pdp_essentials.size_and_fit' | t }}</a>
+            <a href="{{ block.settings.size_guide_page.url }}"{% unless block.settings.link_behavior == 'modal' %} target="_blank" rel="noopener"{% endunless %} data-size-guide-link data-event="pdp_essentials_click" data-item="size">{{ size_text }}</a>
           </li>
         {%- endif -%}
       </ul>
   {% endcase %}
 
   {%- assign trust_line_setting = block.settings.trust_line -%}
-  {%- if trust_line_setting == blank and block.settings.hide_if_empty -%}
+  {%- if trust_line_setting == blank and hide_if_empty -%}
     {%- assign trust_line_text = blank -%}
   {%- else -%}
     {%- assign trust_line_text = trust_line_setting | default: ('sections.pdp_essentials.trust_line' | t) -%}


### PR DESCRIPTION
## Summary
- verify short text for delivery, returns and size guide
- skip PDP essentials items when hide_if_empty and text is blank
- wire trust line to shared hide_if_empty logic

## Testing
- `theme-check .`


------
https://chatgpt.com/codex/tasks/task_e_6899d22d1dc4832cbbe5f2a02237ec33