### PR TITLE
Add expandable review text with read more toggle

### DIFF
--- a/assets/review-banner-carousel.css
+++ b/assets/review-banner-carousel.css
@@ -435,6 +435,27 @@
   font-weight: 400;
   flex: 1;
   font-style: italic;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+.rbc-review-text.is-expanded {
+  -webkit-line-clamp: unset;
+  display: block;
+  overflow: visible;
+}
+
+.rbc-read-more {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-top: 0.8rem;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 /* Review Metadata */

--- a/assets/review-banner-carousel.js
+++ b/assets/review-banner-carousel.js
@@ -304,6 +304,7 @@
       
       this.state.slides = Array.from(this.originalContent.children);
       this.updateSlideAttributes();
+      this.setupReadMoreButtons();
     }
 
     updateSlideAttributes() {
@@ -312,6 +313,33 @@
         slide.setAttribute('aria-setsize', this.state.slides.length);
         slide.setAttribute('aria-posinset', index + 1);
         slide.setAttribute('tabindex', index === 0 ? '0' : '-1');
+      });
+    }
+
+    setupReadMoreButtons() {
+      this.state.slides.forEach(slide => {
+        const textEl = slide.querySelector('.rbc-review-text');
+        if (!textEl) return;
+
+        const existingButton = slide.querySelector('.rbc-read-more');
+        if (existingButton) existingButton.remove();
+        textEl.classList.remove('is-expanded');
+
+        if (textEl.scrollHeight > textEl.clientHeight + 1) {
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'rbc-read-more';
+          btn.setAttribute('aria-expanded', 'false');
+          btn.textContent = 'Read more';
+
+          btn.addEventListener('click', () => {
+            const expanded = textEl.classList.toggle('is-expanded');
+            btn.textContent = expanded ? 'Read less' : 'Read more';
+            btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+          });
+
+          textEl.after(btn);
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- Clamp review text to three lines and style minimal read-more toggle
- Add accessibility-friendly toggle logic to expand and collapse long reviews

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b042600832ca6c419949d7d0543