### PR TITLE
Fix review carousel responsiveness and clarity

### DIFF
--- a/assets/review-banner-carousel.css
+++ b/assets/review-banner-carousel.css
@@ -91,6 +91,14 @@
   mask-image: var(--rbc-gradient-mask);
   -webkit-mask-image: var(--rbc-gradient-mask);
 }
+.rbc-section:not(.rbc-full-width) .rbc-carousel-wrapper {
+  width: 100%;
+  margin-left: 0;
+  transform: none;
+  mask-image: none;
+  -webkit-mask-image: none;
+}
+
 
 .rbc-carousel-track {
   display: flex;
@@ -151,11 +159,24 @@
 
 /* Premium Card Design */
 .rbc-slide {
-  flex: 0 0 auto;
+  flex: 0 0 calc((100% - (var(--rbc-slides-mobile) - 1) * var(--rbc-gap-mobile)) / var(--rbc-slides-mobile));
+}
+@media screen and (min-width: 750px) {
+  .rbc-slide {
+    flex: 0 0 calc((100% - (var(--rbc-slides-tablet) - 1) * var(--rbc-gap)) / var(--rbc-slides-tablet));
+  }
 }
 
+@media screen and (min-width: 990px) {
+  .rbc-slide {
+    flex: 0 0 calc((100% - (var(--rbc-slides-desktop) - 1) * var(--rbc-gap)) / var(--rbc-slides-desktop));
+  }
+}
+
+
+
 .rbc-card {
-  width: clamp(280px, 32vw, 360px);
+  width: 100%;
   height: auto;
   background: rgb(var(--color-background));
   border-radius: var(--rbc-border-radius);

--- a/sections/review-banner-carousel.liquid
+++ b/sections/review-banner-carousel.liquid
@@ -43,6 +43,7 @@
   assign enable_analytics = section.settings.enable_analytics
   assign lazy_load_strategy = section.settings.lazy_load_strategy | default: 'intersection'
   assign image_aspect_ratio = section.settings.image_aspect_ratio | default: 'auto'
+  assign enable_blur_up = section.settings.enable_blur_up
   
   # Filter and limit reviews for performance
   if max_reviews_display > 0
@@ -76,8 +77,8 @@
     --rbc-slides-mobile: {{ slides_mobile }};
     --rbc-slides-tablet: {{ slides_tablet }};
     --rbc-slides-desktop: {{ slides_desktop }};
-    --rbc-slide-gap-mobile: {{ section.settings.slide_gap_mobile | default: 16 }}px;
-    --rbc-slide-gap-desktop: {{ section.settings.slide_gap_desktop | default: 24 }}px;
+    --rbc-gap-mobile: {{ section.settings.slide_gap_mobile | default: 16 }}px;
+    --rbc-gap: {{ section.settings.slide_gap_desktop | default: 24 }}px;
     
     /* Color scheme integration */
     --rbc-bg-primary: rgb(var(--color-{{ color_scheme }}-background));
@@ -393,8 +394,9 @@
                           loading: image_loading,
                           sizes: '(max-width: 749px) 90vw, (max-width: 989px) 45vw, 33vw',
                           class: 'rbc-image',
-                          aspect_ratio: image_aspect_ratio
-                        -%}
+                          aspect_ratio: image_aspect_ratio,
+                          blur_up: enable_blur_up
+                          -%}
                       {%- endif -%}
                     </div>
                     {%- if product_title != blank and product_image != blank and has_video == false -%}
@@ -794,6 +796,12 @@
         {"value": "intersection", "label": "Intersection observer"}
       ],
       "default": "intersection"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_blur_up",
+      "label": "Enable blur-up placeholder",
+      "default": false
     },
     {
       "type": "header",


### PR DESCRIPTION
## Summary
- respect slide count and gap settings for responsive layouts
- add optional blur-up loading placeholder for review images
- correct carousel alignment when not full width

## Testing
- `theme-check` *(fails: ParserBlockingJavaScript, Missing width/height, RemoteAsset, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a86e0b3e68832cbdb7daa99c76028a