### PR TITLE
Restrict review banner carousel breakout to full-width sections

### DIFF
--- a/assets/review-banner-carousel.css
+++ b/assets/review-banner-carousel.css
@@ -84,19 +84,16 @@
 /* Advanced Carousel System */
 .rbc-carousel-wrapper {
   position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+
+.rbc-section.rbc-full-width .rbc-carousel-wrapper {
   width: 100vw;
   margin-left: 50%;
   transform: translateX(-50%);
-  overflow: hidden;
   mask-image: var(--rbc-gradient-mask);
   -webkit-mask-image: var(--rbc-gradient-mask);
-}
-.rbc-section:not(.rbc-full-width) .rbc-carousel-wrapper {
-  width: 100%;
-  margin-left: 0;
-  transform: none;
-  mask-image: none;
-  -webkit-mask-image: none;
 }
 
 


### PR DESCRIPTION
## Summary
- scope full-width breakout to sections with `rbc-full-width`
- fall back to container width for standard layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f6be004832c9fcde4db14498fd9