### PR TITLE
Respect card size settings in review carousel

### DIFF
--- a/assets/review-banner-carousel.css
+++ b/assets/review-banner-carousel.css
@@ -156,25 +156,18 @@
 
 /* Premium Card Design */
 .rbc-slide {
-  flex: 0 0 calc((100% - (var(--rbc-slides-mobile) - 1) * var(--rbc-gap-mobile)) / var(--rbc-slides-mobile));
-}
-@media screen and (min-width: 750px) {
-  .rbc-slide {
-    flex: 0 0 calc((100% - (var(--rbc-slides-tablet) - 1) * var(--rbc-gap)) / var(--rbc-slides-tablet));
-  }
-}
-
-@media screen and (min-width: 990px) {
-  .rbc-slide {
-    flex: 0 0 calc((100% - (var(--rbc-slides-desktop) - 1) * var(--rbc-gap)) / var(--rbc-slides-desktop));
-  }
+  display: flex;
+  flex: 0 0 var(--rbc-card-width);
+  max-width: var(--rbc-card-width);
+  justify-content: center;
 }
 
 
 
 .rbc-card {
-  width: 100%;
-  height: auto;
+  width: var(--rbc-card-width);
+  max-width: 100%;
+  height: var(--rbc-card-height);
   background: rgb(var(--color-background));
   border-radius: var(--rbc-border-radius);
   overflow: hidden;

--- a/sections/review-banner-carousel.liquid
+++ b/sections/review-banner-carousel.liquid
@@ -80,6 +80,8 @@
     --rbc-slides-desktop: {{ slides_desktop }};
     --rbc-gap-mobile: {{ section.settings.slide_gap_mobile | default: 16 }}px;
     --rbc-gap: {{ section.settings.slide_gap_desktop | default: 24 }}px;
+    --rbc-card-width: {{ section.settings.card_width | default: 360 }}px;
+    --rbc-card-height: {{ section.settings.card_height | default: 520 }}px;
     
     /* Color scheme integration */
     --rbc-bg-primary: rgb(var(--color-{{ color_scheme }}-background));


### PR DESCRIPTION
## Summary
- expose card width and height settings as CSS variables
- size and center cards in carousel using those variables

## Testing
- `theme-check` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a881ea10e4832ca7c8a130ead8b73f